### PR TITLE
Changing fault handling to use PV prefixes from the spreadsheet instead of from the scLinac utility class

### DIFF
--- a/backend/backEnd_constants.py
+++ b/backend/backEnd_constants.py
@@ -23,14 +23,17 @@ class DisplayCavity(Cavity, object):
 
                 # Rack A cavities don't care about faults for Rack B and vice versa
                 if csvFault["Rack"] != self.rack.rackName:
+                    # Takes us to the next iteration of the for loop
                     continue
 
+            # tested in the python console that strings without one of these
+            # formatting keys just ignores them and moves on
             prefix = csvFault["PV Prefix"].format(LINAC=self.linac.name,
                                                   CRYOMODULE=self.cryomodule.name,
                                                   RACK=self.rack.rackName,
                                                   CAVITY=self.number)
 
-            self.faults.append(Fault(tlc=csvFault["Severity"],
+            self.faults.append(Fault(tlc=csvFault["Three Letter Code"],
                                      severity=csvFault["Severity"],
                                      suffix=csvFault["PV Suffix"],
                                      okValue=csvFault["OK If Equal To"],

--- a/backend/backEnd_constants.py
+++ b/backend/backEnd_constants.py
@@ -27,7 +27,8 @@ class DisplayCavity(Cavity, object):
 
             prefix = csvFault["PV Prefix"].format(LINAC=self.linac.name,
                                                   CRYOMODULE=self.cryomodule.name,
-                                                  RACK=self.rack.rackName)
+                                                  RACK=self.rack.rackName,
+                                                  CAVITY=self.number)
 
             self.faults.append(Fault(tlc=csvFault["Severity"],
                                      severity=csvFault["Severity"],

--- a/backend/fault.py
+++ b/backend/fault.py
@@ -45,6 +45,5 @@ csvFile = DictReader(open("faults.csv"))
 
 CSV_FAULTS: List[Dict] = []
 for row in csvFile:
-    print(row)
     if row["PV Suffix"]:
         CSV_FAULTS.append(row)

--- a/backend/fault.py
+++ b/backend/fault.py
@@ -22,9 +22,6 @@ class Fault:
 
         self.pv: PV = PV(prefix + ":" + suffix, connection_timeout=PV_TIMEOUT)
 
-    def __str__(self):
-        return ', '.join("%s: %s" % item for item in vars(self).items())
-
     def isFaulted(self):
         if self.pv.status is None:
             raise PvInvalid(self.pv.pvname)

--- a/backend/fault.py
+++ b/backend/fault.py
@@ -1,9 +1,8 @@
-import sys
-from csv import reader, DictReader
+from csv import DictReader
 from epics import PV
+from typing import Dict, List
 
-sys.path.insert(0, '..')
-from lcls_tools.devices.scLinac import LINACS, Cavity
+PV_TIMEOUT = 0.01
 
 
 class PvInvalid(Exception):
@@ -12,53 +11,42 @@ class PvInvalid(Exception):
 
 
 class Fault:
-    def __init__(self, tlc, severity, rank, level, suffix, okValue, faultValue,
-                 rack, description, name):
+    def __init__(self, tlc, severity, suffix, okValue, faultValue, description,
+                 name, prefix):
         self.tlc = tlc
         self.severity = int(severity)
-        self.rank = rank
-        self.level = level
-        self.rack = rack
-        self.suffix = suffix
         self.description = description
         self.name = name
         self.okValue = float(okValue) if okValue else None
         self.faultValue = float(faultValue) if faultValue else None
 
+        self.pv: PV = PV(prefix + ":" + suffix, connection_timeout=PV_TIMEOUT)
+
     def __str__(self):
         return ', '.join("%s: %s" % item for item in vars(self).items())
 
-    def __gt__(self, other):
-        return self.rank > other.rank
-
-    def isFaulted(self, faultPV):
-
-        if faultPV.status is None:
-            raise PvInvalid(faultPV)
+    def isFaulted(self):
+        if self.pv.status is None:
+            raise PvInvalid(self.pv.pvname)
 
         if self.okValue is not None:
-            return faultPV.value != self.okValue
+            return self.pv.value != self.okValue
 
         elif self.faultValue is not None:
-            return faultPV.value == self.faultValue
+            return self.pv.value == self.faultValue
 
         else:
             print(self)
-            raise Exception("Weird state, oh no")
+            raise Exception("Fault has neither \'Fault if equal to\' nor"
+                            " \'OK if equal to\' parameter")
 
 
-faults = []
 csvFile = DictReader(open("faults.csv"))
+
+# Skipping over "parked"
 next(csvFile)
+
+CSV_FAULTS: List[Dict] = []
 for row in csvFile:
     if row["PV Suffix"]:
-        faults.append(Fault(tlc=row["Three Letter Code"],
-                            severity=row["Severity"],
-                            rank=csvFile.line_num,
-                            level=row["Level"],
-                            suffix=row["PV Suffix"],
-                            okValue=row["OK If Equal To"],
-                            faultValue=row["Faulted If Equal To"],
-                            rack=row["Rack"],
-                            description=row["Description"],
-                            name=row["Name"]))
+        CSV_FAULTS.append(row)

--- a/backend/fault.py
+++ b/backend/fault.py
@@ -43,10 +43,8 @@ class Fault:
 
 csvFile = DictReader(open("faults.csv"))
 
-# Skipping over "parked"
-next(csvFile)
-
 CSV_FAULTS: List[Dict] = []
 for row in csvFile:
+    print(row)
     if row["PV Suffix"]:
         CSV_FAULTS.append(row)


### PR DESCRIPTION
Derikka astutely pointed out that the racks have three different kinds of prefix formats for some reason?